### PR TITLE
added results for Apple M4

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ python ./multicore_cpubench -l 50000
 | :heavy_check_mark: | AMD Ryzen 7 4800H | 8 | Windows 11 | 12.572 seconds | 16.202 seconds |
 | :heavy_check_mark: | Intel i5-10210U | 8 | Windows 11 | 32.276 seconds | 44.918 seconds |
 | :heavy_check_mark: | Intel i5-6500T | 4 | Windows 11 | 39.853 seconds | 54.143 seconds |
+| :heavy_check_mark: | Apple M4 | 10 | macOS(Darwin) | 6.775 seconds | 7.255 seconds |
 | :o: | i9-11900H | 16 | Windows 11  | untested | untested |
 | :o: | i5-9300H | 8 | Windows 11  | untested | untested |
 | :o: | i9-11900H | 16 | Windows 11  | untested | untested |


### PR DESCRIPTION
Added results for Apple M4 with 10 Logical cores. 
MacOS mini

```bash
~/pwork/cpu-benchmark-ReZeroE (main*) » python3./multicore_cpubench.py -1 50000
Single-core CPU Benchmark by Alex Dedyura 
Multi-core CPU Benchmark by Kevin Liu
Supports Windows, macOS(Darwin), and Linux
CPU: Apple M4
Logical Cores: 10
Arch: arm64
OS: Darwin 25.1.0

Benchmark in progress...

Benchmark Completed:
Avg. Process Time: 6.775 seconds
Program Execution Time: 7.255 seconds
```

Adding snapshot as well.

<img width="1171" height="324" alt="Screenshot 2025-12-11 at 5 34 48 PM" src="https://github.com/user-attachments/assets/fc70cd44-f93a-4a41-a50f-bd85dcb35297" />
